### PR TITLE
Use lower-case release directory

### DIFF
--- a/otfcc-mac64.rb
+++ b/otfcc-mac64.rb
@@ -21,7 +21,7 @@ class OtfccMac64 < Formula
               "-scheme", "otfccdump",
               "-configuration", "Release"
 
-    bin.install "bin/Release-x64/otfccbuild"
-    bin.install "bin/Release-x64/otfccdump"
+    bin.install "bin/release-x64/otfccbuild"
+    bin.install "bin/release-x64/otfccdump"
   end
 end


### PR DESCRIPTION
The make file uses "release" while the brew formula had "Release". This breaks APFS (or, I reckon, HFS+) with case sensitivity enabled.